### PR TITLE
fix: eliminate phantom dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,6 @@
     "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@babel/parser": "^7.22.10",
-    "@babel/types": "^7.22.10",
     "@baiwusanyu/eslint-config": "^1.0.14",
     "@rollup/pluginutils": "^5.0.2",
     "@types/css-tree": "^2.3.1",

--- a/packages/sub-style/package.json
+++ b/packages/sub-style/package.json
@@ -60,6 +60,8 @@
     "vue": "^3.3.2"
   },
   "dependencies": {
+    "@babel/parser": "^7.22.10",
+    "@babel/types": "^7.22.10",
     "@unplugin-vue-ce/utils": "workspace:*",
     "baiwusanyu-utils": "^1.0.12",
     "estree-walker-ts": "^1.0.0",

--- a/packages/v-model/package.json
+++ b/packages/v-model/package.json
@@ -60,6 +60,8 @@
     "vue": "^3.3.2"
   },
   "dependencies": {
+    "@babel/parser": "^7.22.10",
+    "@babel/types": "^7.22.10",
     "@unplugin-vue-ce/utils": "workspace:*",
     "baiwusanyu-utils": "^1.0.12",
     "estree-walker-ts": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,12 +48,6 @@ importers:
         specifier: ^3.3.4
         version: 3.3.4
     devDependencies:
-      '@babel/parser':
-        specifier: ^7.22.10
-        version: 7.22.10
-      '@babel/types':
-        specifier: ^7.22.10
-        version: 7.22.10
       '@baiwusanyu/eslint-config':
         specifier: ^1.0.14
         version: 1.0.14(eslint@8.46.0)(typescript@5.1.6)
@@ -176,6 +170,12 @@ importers:
 
   packages/sub-style:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.22.10
+        version: 7.22.10
+      '@babel/types':
+        specifier: ^7.22.10
+        version: 7.22.10
       '@unplugin-vue-ce/utils':
         specifier: workspace:*
         version: link:../../utils
@@ -230,6 +230,12 @@ importers:
 
   packages/v-model:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.22.10
+        version: 7.22.10
+      '@babel/types':
+        specifier: ^7.22.10
+        version: 7.22.10
       '@unplugin-vue-ce/utils':
         specifier: workspace:*
         version: link:../../utils


### PR DESCRIPTION
Thanks for `unplugin-vue-ce`. It makes it possible to combine web components and Vue together. Currently, some dependencies are installed at the root level of the workspace, which have turned out to be phantom dependencies for sub-packages. When using `@unplugin-vue-ce/sub-style`, I have to manually patch the missing dependencies. ( see https://github.com/fi3ework/vite-plugin-checker/blob/e5a26d68097b6254a3004ce3495ed79f35857423/package.json#L11-L16)

This PR removes the dependencies from the root. Additionally, some other dependencies have also been revealed, which can be fixed in the future. You can find them [here](https://github.com/fi3ework/vite-plugin-checker/blob/e5a26d68097b6254a3004ce3495ed79f35857423/package.json#L17-L30).